### PR TITLE
Add python3 kernelspec to metadata

### DIFF
--- a/notebooks/palmyra-fin-model-use.ipynb
+++ b/notebooks/palmyra-fin-model-use.ipynb
@@ -305,6 +305,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python"
   }

--- a/notebooks/palmyra-med-model-use.ipynb
+++ b/notebooks/palmyra-med-model-use.ipynb
@@ -316,6 +316,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+    "display_name": "Python 3",
+    "language": "python",
+    "name": "python3"
+  },
   "language_info": {
    "name": "python"
   }


### PR DESCRIPTION
Kruthi from AWS asked us to add kernelspec metadata to the Palmyra Med and Fin notebooks. I used `python3` but can adjust if needed.